### PR TITLE
Add minimal implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,17 @@
 # Plex FUSE Filesystem
 
 An attempt to create fuse filesystem to access Plex Media Server.
+
+## Plex Config
+
+Create Plex [configuration] file:
+
+```ini
+# ~/.config/plexapi/config.ini
+
+[auth]
+server_baseurl = http://127.0.0.1:32400
+server_token = XBHSMSJSDJ763JSm
+```
+
+[configuration]: https://python-plexapi.readthedocs.io/en/latest/configuration.html

--- a/plexfuse/__main__.py
+++ b/plexfuse/__main__.py
@@ -1,0 +1,18 @@
+if len(__package__) == 0:
+    import sys
+
+    print(
+        f"""
+
+The '__main__' module does not seem to have been run in the context of a
+runnable package ... did you forget to add the '-m' flag?
+
+Usage: {sys.executable} -m plexfuse {' '.join(sys.argv[1:])}
+
+"""
+    )
+    sys.exit(2)
+
+from plexfuse.fs.main import main
+
+main()

--- a/plexfuse/fs/PlexDirectory.py
+++ b/plexfuse/fs/PlexDirectory.py
@@ -1,0 +1,10 @@
+import stat
+
+from fuse import Stat
+
+
+class PlexDirectory(Stat):
+    def __init__(self, **kw):
+        super().__init__(**kw)
+        self.st_mode = stat.S_IFDIR | 0o755
+        self.st_nlink = 2

--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -4,9 +4,14 @@ from time import time
 import fuse
 
 from plexfuse.fs.PlexDirectory import PlexDirectory
+from plexfuse.plex.PlexApi import PlexApi
 
 
 class PlexFS(fuse.Fuse):
+    def __init__(self, *args, **kw):
+        super().__init__(*args, **kw)
+        self.plex = PlexApi()
+
     def getattr(self, path: str):
         st = PlexDirectory()
 

--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -14,11 +14,14 @@ class PlexFS(fuse.Fuse):
 
     def getattr(self, path: str):
         st = PlexDirectory()
+        pe = path.split("/")[1:]
 
         st.st_atime = int(time())
         st.st_mtime = st.st_atime
         st.st_ctime = st.st_atime
         if path == "/":
+            pass
+        elif pe[-1] in self.plex.section_types:
             pass
         else:
             return -errno.ENOENT
@@ -26,5 +29,8 @@ class PlexFS(fuse.Fuse):
 
     def readdir(self, path: str, offset: int):
         dirents = [".", ".."]
+        if path == "/":
+            dirents.extend(self.plex.section_types)
+
         for r in dirents:
             yield fuse.Direntry(r)

--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -1,5 +1,25 @@
+import errno
+from time import time
+
 import fuse
+
+from plexfuse.fs.PlexDirectory import PlexDirectory
 
 
 class PlexFS(fuse.Fuse):
-    ...
+    def getattr(self, path: str):
+        st = PlexDirectory()
+
+        st.st_atime = int(time())
+        st.st_mtime = st.st_atime
+        st.st_ctime = st.st_atime
+        if path == "/":
+            pass
+        else:
+            return -errno.ENOENT
+        return st
+
+    def readdir(self, path: str, offset: int):
+        dirents = [".", ".."]
+        for r in dirents:
+            yield fuse.Direntry(r)

--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -1,0 +1,5 @@
+import fuse
+
+
+class PlexFS(fuse.Fuse):
+    ...

--- a/plexfuse/fs/PlexFile.py
+++ b/plexfuse/fs/PlexFile.py
@@ -1,0 +1,5 @@
+from fuse import Stat
+
+
+class PlexFile(Stat):
+    ...

--- a/plexfuse/fs/main.py
+++ b/plexfuse/fs/main.py
@@ -1,0 +1,26 @@
+#
+# A FUSE filesystem for mounting a Plex Media Server in Python
+#
+# Mount with:
+# $ plexfuse <mountpoint>
+# And un-mount with:
+# $ fusermount -u <mountpoint>
+#
+
+import fuse
+
+from plexfuse.fs.PlexFS import PlexFS
+
+fuse.fuse_python_api = (0, 2)
+
+
+def main():
+    usage = "PlexFS: A filesystem for mounting a Plex Media Server media\n\n"
+    server = PlexFS(version="%prog " + fuse.__version__,
+                    usage=usage + fuse.Fuse.fusage, dash_s_do="setsingle")
+    server.parse(errex=1)
+    server.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/plexfuse/plex/PlexApi.py
+++ b/plexfuse/plex/PlexApi.py
@@ -7,3 +7,15 @@ class PlexApi:
     @cached_property
     def server(self):
         return PlexServer()
+
+    @property
+    def library(self):
+        return self.server.library
+
+    @cached_property
+    def sections(self):
+        return self.library.sections()
+
+    @cached_property
+    def section_types(self):
+        return {s.type for s in self.sections}

--- a/plexfuse/plex/PlexApi.py
+++ b/plexfuse/plex/PlexApi.py
@@ -1,0 +1,9 @@
+from functools import cached_property
+
+from plexapi.server import PlexServer
+
+
+class PlexApi:
+    @cached_property
+    def server(self):
+        return PlexServer()


### PR DESCRIPTION
Implements:
- [x] Implements listing of root directory
- [x] Connecting to PMS via python-plexapi
- [x] Implements listing of library types in root directory


Currently crashes (on macOS) without debug mode (`-d`), so must enable debug mode.

Usage:

Terminal 1:
```
python -m plexfuse ./tmp -d
```

Terminal 2:

```
$ ls -la tmp
total 0
drwxr-xr-x  2 root wheel   0 Dec 13 22:33 ./
drwxr-xr-x 21 glen staff 672 Dec 13 22:23 ../
drwxr-xr-x  2 root wheel   0 Dec 13 22:33 artist/
drwxr-xr-x  2 root wheel   0 Dec 13 22:33 movie/
drwxr-xr-x  2 root wheel   0 Dec 13 22:33 show/
```