### PR TITLE
Fix: Use KeyError rather IndexError

### DIFF
--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -19,7 +19,7 @@ class PlexFS(fuse.Fuse):
     def getattr(self, path: str):
         try:
             item = self.vfs[path]
-        except IndexError as e:
+        except KeyError as e:
             print(e)
             return -errno.ENOENT
 
@@ -38,7 +38,7 @@ class PlexFS(fuse.Fuse):
 
         try:
             it = self.vfs[path]
-        except IndexError as e:
+        except KeyError as e:
             print(e)
             return
 

--- a/plexfuse/plex/PlexVFS.py
+++ b/plexfuse/plex/PlexVFS.py
@@ -18,7 +18,7 @@ class PlexVFS(UserDict):
     def __missing__(self, path: str):
         entry = self.resolve(path)
         if entry is None:
-            raise IndexError(f"Unsupported path: {path}")
+            raise KeyError(f"Unsupported path: {path}")
 
         self[path] = entry
 


### PR DESCRIPTION
Accessing dict item that does not exist throws KeyError