### PR TITLE
Fix: Use 8mb chunk size

### DIFF
--- a/plexfuse/plex/PlexApi.py
+++ b/plexfuse/plex/PlexApi.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
 class PlexApi:
     CACHE_PATH = Path("cache")
     CACHE_VERSION = str(2)
+    CHUNK_SIZE = 1024 * 1024 * 16
 
     @cached_property
     def server(self):
@@ -141,7 +142,7 @@ class PlexApi:
         makedirs(Path(savepath).parent, exist_ok=True)
 
         with open(savepath, "wb") as handle:
-            for chunk in response.iter_content(chunk_size=None):
+            for chunk in response.iter_content(chunk_size=self.CHUNK_SIZE):
                 handle.write(chunk)
 
         return savepath


### PR DESCRIPTION
Using `chunk_size=None` will really use one chunk for whole file, although I was expecting some "best" size to be used.