### PR TITLE
Update to use python3.11

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,4 +1,4 @@
-layout python python3.10
+layout python python3.11
 
 # Pipenv found itself running within a virtual environment,
 # so it will automatically use that environment,

--- a/Pipfile
+++ b/Pipfile
@@ -10,4 +10,4 @@ fuse-python = "==1.0.7"
 [dev-packages]
 
 [requires]
-python_version = "3.10"
+python_version = "3.11"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,11 +1,11 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c2b7d1f77dd1b7aab6367035c9a38dd5d2b21512ff255937c0a46bc091327e12"
+            "sha256": "4450b3629f4102803c67ae780b0670d1f82736b4f9319db688800f8e262a296e"
         },
         "pipfile-spec": 6,
         "requires": {
-            "python_version": "3.10"
+            "python_version": "3.11"
         },
         "sources": [
             {


### PR DESCRIPTION
No specific reason, other than a convenience, as it's default on Debian 12