### PR TITLE
Fix: Guard access beyond end of file

### DIFF
--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -63,8 +63,12 @@ class PlexFS(fuse.Fuse):
         file_path = self.file_map[path].key
         max_size = self.file_map[path].size
 
-        with self.iolock:
-            return self.reader.read(file_path, size=size, offset=offset, max_size=max_size)
+        try:
+            with self.iolock:
+                return self.reader.read(file_path, size=size, offset=offset, max_size=max_size)
+        except EOFError as e:
+            print(f"read({path}): {e}")
+            return -errno.ENXIO
 
     def release(self, path, flags):
         try:

--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -60,10 +60,11 @@ class PlexFS(fuse.Fuse):
             yield fuse.Direntry(str(r))
 
     def read(self, path, size, offset):
-        file_path = self.file_map[path]
+        file_path = self.file_map[path].key
+        max_size = self.file_map[path].size
 
         with self.iolock:
-            return self.reader.read(file_path, size=size, offset=offset)
+            return self.reader.read(file_path, size=size, offset=offset, max_size=max_size)
 
     def release(self, path, flags):
         try:
@@ -84,6 +85,6 @@ class PlexFS(fuse.Fuse):
         if not isinstance(part, PlexVFSFileEntry):
             return -errno.EISDIR
 
-        self.file_map[path] = part.key
+        self.file_map[path] = part
 
         return 0

--- a/plexfuse/plex/ChunkedFile.py
+++ b/plexfuse/plex/ChunkedFile.py
@@ -16,6 +16,7 @@ class ChunkedFile:
         self.files = FileCache()
 
     def read(self, path: str, offset: int, size: int, max_size: int):
+        print(f"read: {path}, offset={offset}, size={size}, max_size={max_size}")
         chunk_number = self.chunk_number(offset)
         chunk_offset = self.chunk_offset(offset)
 

--- a/plexfuse/plex/ChunkedFile.py
+++ b/plexfuse/plex/ChunkedFile.py
@@ -17,9 +17,9 @@ class ChunkedFile:
 
     def read(self, path: str, offset: int, size: int, max_size: int):
         print(f"read: {path}, offset={offset}, size={size}, max_size={max_size} -> remaining {max_size-offset} to read {max_size-offset+size}")
-        if max_size-offset+size > max_size-offset:
-            size = max_size - offset
-            print(f"avoid reading beyond end of file, adjusting size to {size}")
+#        if max_size-offset+size > max_size-offset:
+#            size = max_size - offset
+#            print(f"avoid reading beyond end of file, adjusting size to {size}")
         chunk_number = self.chunk_number(offset)
         chunk_offset = self.chunk_offset(offset)
 

--- a/plexfuse/plex/ChunkedFile.py
+++ b/plexfuse/plex/ChunkedFile.py
@@ -16,10 +16,13 @@ class ChunkedFile:
         self.files = FileCache()
 
     def read(self, path: str, offset: int, size: int, max_size: int):
-        print(f"read: {path}, offset={offset}, size={size}, max_size={max_size} -> remaining {max_size-offset} to read {max_size-offset+size}")
-#        if max_size-offset+size > max_size-offset:
-#            size = max_size - offset
-#            print(f"avoid reading beyond end of file, adjusting size to {size}")
+        start_pos = max_size - offset
+        end_pos = start_pos + size
+        print(f"read: {path}, offset={offset}, size={size}, max_size={max_size}"
+              f" -> remaining {start_pos} to read {end_pos}")
+        if offset + size > max_size:
+            size = max_size - offset
+            print(f"avoid reading beyond end of file, adjusting size to {size}")
         chunk_number = self.chunk_number(offset)
         chunk_offset = self.chunk_offset(offset)
 

--- a/plexfuse/plex/ChunkedFile.py
+++ b/plexfuse/plex/ChunkedFile.py
@@ -19,7 +19,7 @@ class ChunkedFile:
         print(f"read: {path}, offset={offset}, size={size}, max_size={max_size} -> remaining {max_size-offset} to read {max_size-offset+size}")
         if max_size-offset+size > max_size-offset:
             size = max_size - offset
-            print(f"avoid reading beyond end of file, adjusting size to {size}"
+            print(f"avoid reading beyond end of file, adjusting size to {size}")
         chunk_number = self.chunk_number(offset)
         chunk_offset = self.chunk_offset(offset)
 

--- a/plexfuse/plex/ChunkedFile.py
+++ b/plexfuse/plex/ChunkedFile.py
@@ -18,11 +18,13 @@ class ChunkedFile:
     def read(self, path: str, offset: int, size: int, max_size: int):
         start_pos = max_size - offset
         end_pos = start_pos + size
+        warning = False
         print(f"read: {path}, offset={offset}, size={size}, max_size={max_size}"
               f" -> remaining {start_pos} to read {end_pos}")
         if offset + size > max_size:
             size = max_size - offset
             print(f"avoid reading beyond end of file, adjusting size to {size}")
+            warning = True
         chunk_number = self.chunk_number(offset)
         chunk_offset = self.chunk_offset(offset)
 
@@ -34,6 +36,9 @@ class ChunkedFile:
                 fp.seek(chunk_offset)
                 buffer = fp.read(size)
                 read_bytes = len(buffer)
+                if warning:
+                    print(f"Check condition: seek:{chunk_offset}, must_read:{size},"
+                          f"  actual_read:{read_bytes}, remaining size={size - read_bytes}")
                 size -= read_bytes
                 reads.append(buffer)
 

--- a/plexfuse/plex/ChunkedFile.py
+++ b/plexfuse/plex/ChunkedFile.py
@@ -17,6 +17,9 @@ class ChunkedFile:
 
     def read(self, path: str, offset: int, size: int, max_size: int):
         print(f"read: {path}, offset={offset}, size={size}, max_size={max_size} -> remaining {max_size-offset} to read {max_size-offset+size}")
+        if max_size-offset+size > max_size-offset:
+            size = max_size - offset
+            print(f"avoid reading beyond end of file, adjusting size to {size}"
         chunk_number = self.chunk_number(offset)
         chunk_offset = self.chunk_offset(offset)
 

--- a/plexfuse/plex/ChunkedFile.py
+++ b/plexfuse/plex/ChunkedFile.py
@@ -40,7 +40,7 @@ class ChunkedFile:
                 buffer = fp.read(size)
                 read_bytes = len(buffer)
                 if warning:
-                    print(f"Check condition: seek:{chunk_offset}, must_read:{size},"
+                    print(f"Check condition: chunk:{chunk_number}, seek:{chunk_offset}, must_read:{size},"
                           f"  actual_read:{read_bytes}, remaining size={size - read_bytes}")
                 size -= read_bytes
                 reads.append(buffer)

--- a/plexfuse/plex/ChunkedFile.py
+++ b/plexfuse/plex/ChunkedFile.py
@@ -25,6 +25,9 @@ class ChunkedFile:
             size = max_size - offset
             print(f"avoid reading beyond end of file, adjusting size to {size}")
             warning = True
+        if offset == 663977984 and size == 1156:
+            print("On macos, set warning true")
+            warning = True
         chunk_number = self.chunk_number(offset)
         chunk_offset = self.chunk_offset(offset)
 

--- a/plexfuse/plex/ChunkedFile.py
+++ b/plexfuse/plex/ChunkedFile.py
@@ -16,7 +16,7 @@ class ChunkedFile:
         self.files = FileCache()
 
     def read(self, path: str, offset: int, size: int, max_size: int):
-        print(f"read: {path}, offset={offset}, size={size}, max_size={max_size}")
+        print(f"read: {path}, offset={offset}, size={size}, max_size={max_size} -> remaining {max_size-offset} to read {max_size-offset+size}")
         chunk_number = self.chunk_number(offset)
         chunk_offset = self.chunk_offset(offset)
 

--- a/plexfuse/plex/FileCache.py
+++ b/plexfuse/plex/FileCache.py
@@ -31,8 +31,8 @@ class FileCache(UserDict[str, BinaryIO]):
         self.nopen[path] -= 1
         if self.nopen[path] <= 0:
             fh = self[path]
-            fh.close()
             del self[path]
+            fh.close()
 
     def _open(self, path: str):
         try:

--- a/plexfuse/plex/FileCache.py
+++ b/plexfuse/plex/FileCache.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections import UserDict, defaultdict
 from contextlib import contextmanager
+from pathlib import Path
 from typing import BinaryIO
 
 
@@ -11,7 +12,8 @@ class FileCache(UserDict[str, BinaryIO]):
         self.nopen = defaultdict(int)
 
     @contextmanager
-    def cached_fh(self, path: str):
+    def cached_fh(self, path: str | Path):
+        path = str(path)
         try:
             yield self.open(path)
         finally:

--- a/plexfuse/plex/FileCache.py
+++ b/plexfuse/plex/FileCache.py
@@ -21,10 +21,8 @@ class FileCache(UserDict[str, BinaryIO]):
 
     def open(self, path: str):
         if path not in self:
-            print(f"open: {path}, refcount={self.nopen[path]}")
             self[path] = self._open(path)
             self.nopen[path] += 1
-            print(f"opened: {path}, refcount={self.nopen[path]}")
 
         return self[path]
 
@@ -34,11 +32,9 @@ class FileCache(UserDict[str, BinaryIO]):
 
         self.nopen[path] -= 1
         if self.nopen[path] <= 0:
-            print(f"close: {path}, refcount={self.nopen[path]}")
             fh = self[path]
             del self[path]
             fh.close()
-            print(f"closed: {path}, refcount={self.nopen[path]}")
 
     def _open(self, path: str):
         try:

--- a/plexfuse/plex/FileCache.py
+++ b/plexfuse/plex/FileCache.py
@@ -21,8 +21,10 @@ class FileCache(UserDict[str, BinaryIO]):
 
     def open(self, path: str):
         if path not in self:
+            print(f"open: {path}, refcount={self.nopen[path]}")
             self[path] = self._open(path)
             self.nopen[path] += 1
+            print(f"opened: {path}, refcount={self.nopen[path]}")
 
         return self[path]
 
@@ -32,9 +34,11 @@ class FileCache(UserDict[str, BinaryIO]):
 
         self.nopen[path] -= 1
         if self.nopen[path] <= 0:
+            print(f"close: {path}, refcount={self.nopen[path]}")
             fh = self[path]
             del self[path]
             fh.close()
+            print(f"closed: {path}, refcount={self.nopen[path]}")
 
     def _open(self, path: str):
         try:

--- a/plexfuse/plex/PlexApi.py
+++ b/plexfuse/plex/PlexApi.py
@@ -143,6 +143,9 @@ class PlexApi:
         response = self.session.get(url, headers=headers, stream=True)
         if response.status_code not in accepted_status:
             message = f"({response.status_code}): {response.url}"
+            # https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/416
+            if response.status_code == 416:
+                message += f" Range: {headers.get('range', None)}"
             raise RuntimeError(message)
 
         yield from response.iter_content(chunk_size=self.CHUNK_SIZE)


### PR DESCRIPTION
Somewhy on Linux, it's attempted to access beyond end of the file, and such requests cause 416 error.