### PR TITLE
Fix: Adjust size to avoid running out of file end

### DIFF
--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -60,10 +60,11 @@ class PlexFS(fuse.Fuse):
             yield fuse.Direntry(str(r))
 
     def read(self, path, size, offset):
-        file_path = self.file_map[path]
+        file_path = self.file_map[path].key
+        max_size = self.file_map[path].size
 
         with self.iolock:
-            return self.reader.read(file_path, size=size, offset=offset)
+            return self.reader.read(file_path, size=size, offset=offset, max_size=max_size)
 
     def release(self, path, flags):
         try:
@@ -84,6 +85,6 @@ class PlexFS(fuse.Fuse):
         if not isinstance(part, PlexVFSFileEntry):
             return -errno.EISDIR
 
-        self.file_map[path] = part.key
+        self.file_map[path] = part
 
         return 0

--- a/plexfuse/plex/ChunkedFile.py
+++ b/plexfuse/plex/ChunkedFile.py
@@ -15,7 +15,7 @@ class ChunkedFile:
         self.chunk_size = plex.CHUNK_SIZE
         self.files = FileCache()
 
-    def read(self, path: str, offset: int, size: int):
+    def read(self, path: str, offset: int, size: int, max_size: int):
         chunk_number = self.chunk_number(offset)
         chunk_offset = self.chunk_offset(offset)
 

--- a/plexfuse/plex/ChunkedFile.py
+++ b/plexfuse/plex/ChunkedFile.py
@@ -16,6 +16,9 @@ class ChunkedFile:
         self.files = FileCache()
 
     def read(self, path: str, offset: int, size: int, max_size: int):
+        # To avoid reading beyond end of file, adjusting size
+        if offset + size > max_size:
+            size = max_size - offset
         chunk_number = self.chunk_number(offset)
         chunk_offset = self.chunk_offset(offset)
 


### PR DESCRIPTION
_Extracted from https://github.com/glensc/plex-fuse/pull/27_


on macOS, the read call gets proper size to read:

```
read: /library/parts/1111836/1585992024/file.mkv, offset=663928832, size=16384, max_size=663979140 -> remaining 50308
read: /library/parts/1111836/1585992024/file.mkv, offset=663945216, size=16384, max_size=663979140 -> remaining 33924
read: /library/parts/1111836/1585992024/file.mkv, offset=663961600, size=16384, max_size=663979140 -> remaining 17540
read: /library/parts/1111836/1585992024/file.mkv, offset=663977984, size=1156, max_size=663979140 -> remaining 1156
On macos, set warning true
Check condition: chunk:39, seek:9666560, must_read:1156,  actual_read:1156, remaining size=0
```

but on Linux, the size is smaller, but will still go out of bounds

```
read: /library/parts/1111836/1585992024/file.mkv, offset=663158784, size=262144, max_size=663979140 -> remaining 820356
read: /library/parts/1111836/1585992024/file.mkv, offset=663420928, size=262144, max_size=663979140 -> remaining 558212
read: /library/parts/1111836/1585992024/file.mkv, offset=663683072, size=262144, max_size=663979140 -> remaining 296068
read: /library/parts/1111836/1585992024/file.mkv, offset=663945216, size=49152, max_size=663979140 -> remaining 33924
avoid reading beyond end of file, adjusting size to 33924
Check condition: chunk:39, seek:9633792, must_read:33924,  actual_read:33924, remaining size=0
```