### PR TITLE
Add dockerfile to build wheel for debian 11

### DIFF
--- a/Dockerfile.debian
+++ b/Dockerfile.debian
@@ -1,0 +1,33 @@
+# syntax = docker/dockerfile:1.3-labs
+#
+# Build wheel for debian 12 in docker
+# $ export DOCKER_BUILDKIT=1
+# $ docker build -f Dockerfile.debian . -o wheels
+# $ pip install wheels/*.whl
+#
+# Author: Elan Ruusamäe <glen@pld-linux.org>
+
+FROM python:3.11-bookworm AS base
+ENV PIP_DISABLE_PIP_VERSION_CHECK=1
+ENV PIP_ROOT_USER_ACTION=ignore
+
+FROM base AS build-wheels
+RUN \
+	--mount=type=cache,id=pip,target=/root/.cache/pip \
+	--mount=type=cache,id=apt-cache,target=/var/cache/apt \
+	--mount=type=cache,id=apt-lib,target=/var/lib/apt \
+<<eot
+	# Add dev deps
+	apt update && apt install -y --no-install-recommends libfuse-dev
+
+	# Download wheels/sources
+	pip download --dest /wheels fuse-python
+
+	# Build missing wheels
+	set -- $(ls /wheels/*.gz /wheels/*.zip 2>/dev/null)
+	pip wheel "$@" --wheel-dir=/wheels
+eot
+
+# docker build -f Dockerfile.debian . -o wheels
+FROM scratch AS wheels
+COPY --from=build-wheels /wheels .


### PR DESCRIPTION
I don't want to clutter my real system with dev deps, so build the wheel in docker :)

based on my previous work:
- https://github.com/Taxel/PlexTraktSync/blob/7dc2489e12ae285bd21933f4ee95f14d706d56a5/Dockerfile#L20-L35