### PR TITLE
Fix: Force program name instead lfwof __main__

### DIFF
--- a/plexfuse/__main__.py
+++ b/plexfuse/__main__.py
@@ -1,5 +1,6 @@
+import sys
+
 if len(__package__) == 0:
-    import sys
 
     print(
         f"""
@@ -14,5 +15,8 @@ Usage: {sys.executable} -m plexfuse {' '.join(sys.argv[1:])}
     sys.exit(2)
 
 from plexfuse.fs.main import main
+
+# Ensure that program shows in usage (not __main__.py)
+sys.argv[0] = __package__
 
 main()


### PR DESCRIPTION
Inspired from:
- https://github.com/jongracecox/anybadge/blob/cc5a757663a754ff3b32f510bcdeccf995fbfcae/anybadge/__main__.py#L4-L7

```
python -m plexfuse --help
```

```diff
@@ -1,6 +1,6 @@
 Usage: PlexFS: A filesystem for mounting a Plex Media Server media
 
-__main__.py [mountpoint] [options]
+plexfuse [mountpoint] [options]
 
 Options:
     --version              show program's version number and exit
```