### PR TITLE
Fix: Fix concurrent access of same file on Linux

### DIFF
--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -11,6 +11,7 @@ from plexfuse.plex.ChunkedFile import ChunkedFile
 from plexfuse.plex.PlexApi import PlexApi
 from plexfuse.plex.PlexVFS import PlexVFS
 from plexfuse.plex.PlexVFSFileEntry import PlexVFSFileEntry
+from plexfuse.plex.RefCountedDict import RefCountedDict
 
 
 class PlexFS(fuse.Fuse):
@@ -19,7 +20,7 @@ class PlexFS(fuse.Fuse):
         plex = PlexApi()
         self.vfs = PlexVFS(plex)
         self.cache_path = None
-        self.file_map = {}
+        self.file_map = RefCountedDict()
         self.reader = ChunkedFile(plex)
         self.iolock = Lock()
 


### PR DESCRIPTION
Requires:
- https://github.com/glensc/plex-fuse/pull/34

So if the same file is opened twice, the reference is removed only if last value is removed.

tested on Linux (on macOS parallel access is blocked)

```
$ parallel -n0 file test.mkv -L ::: {1..10}
```