### PR TITLE
Fix: Use basename for sys.argv[0] for cleaner /proc/mounts

### DIFF
--- a/plexfuse/__main__.py
+++ b/plexfuse/__main__.py
@@ -1,4 +1,5 @@
 import sys
+from os.path import basename
 
 if len(__package__) == 0:
 
@@ -17,6 +18,6 @@ Usage: {sys.executable} -m plexfuse {' '.join(sys.argv[1:])}
 from plexfuse.fs.main import main
 
 # Ensure that program shows in usage (not __main__.py)
-sys.argv[0] = __package__
+sys.argv[0] = basename(__package__)
 
 main()


### PR DESCRIPTION
Do basename or mtab looks weird


mtab:

```diff
-/home/glen/plex-fuse/plexfuse on /mnt/Pupu type fuse.plexfuse (ro,nosuid,nodev,relatime,user_id=1000,group_id=1000,allow_other)
+plexfuse /mnt/Pupu fuse.plexfuse ro,nosuid,nodev,relatime,user_id=1000,group_id=1000,allow_other 0 0
```


- https://github.com/glensc/plex-fuse/pull/31#issuecomment-1913131445