### PR TITLE
Feature: Improve performance by caching plex api requests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ name = "pypi"
 [packages]
 fuse-python = "==1.0.7"
 plexapi = "==4.15.7"
+requests-cache = "==1.1.1"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "0907d8c03458f1539aed80b61b5293f08b765bd156e8d40e66f213027b88b818"
+            "sha256": "a0af9a27e354096cb67c6f103b2f32c3873e85bb9e3c0819084a4d871904816c"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -16,13 +16,29 @@
         ]
     },
     "default": {
+        "attrs": {
+            "hashes": [
+                "sha256:935dc3b529c262f6cf76e50877d35a4bd3c1de194fd41f47a2b7ae8f19971f30",
+                "sha256:99b87a485a5820b23b879f04c2305b44b951b502fd64be915879d77a7e8fc6f1"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==23.2.0"
+        },
+        "cattrs": {
+            "hashes": [
+                "sha256:0341994d94971052e9ee70662542699a3162ea1e0c62f7ce1b4a57f563685108",
+                "sha256:a934090d95abaa9e911dac357e3a8699e0b4b14f8529bcc7d2b1ad9d51672b9f"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==23.2.3"
+        },
         "certifi": {
             "hashes": [
-                "sha256:9b469f3a900bf28dc19b8cfbf8019bf47f7fdd1a65a1d4ffb98fc14166beb4d1",
-                "sha256:e036ab49d5b79556f99cfc2d9320b34cfbe5be05c5871b51de9329f0603b0474"
+                "sha256:0569859f95fc761b18b45ef421b1290a0f65f147e92a1e5eb3e635f9a5e4e66f",
+                "sha256:dc383c07b76109f368f6106eee2b593b04a011ea4d55f652c6ca24a754d1cdd1"
             ],
             "markers": "python_version >= '3.6'",
-            "version": "==2023.11.17"
+            "version": "==2024.2.2"
         },
         "charset-normalizer": {
             "hashes": [
@@ -136,6 +152,14 @@
             "markers": "python_version >= '3.5'",
             "version": "==3.6"
         },
+        "platformdirs": {
+            "hashes": [
+                "sha256:0614df2a2f37e1a662acbd8e2b25b92ccf8632929bc6d43467e17fe89c75e068",
+                "sha256:ef0cc731df711022c174543cb70a9b5bd22e5a9337c8624ef2c2ceb8ddad8768"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.2.0"
+        },
         "plexapi": {
             "hashes": [
                 "sha256:0d3d633e930e15a8d455313864485a7d4e3e25f7205d41805309582fad9a56e9",
@@ -153,13 +177,38 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.31.0"
         },
+        "requests-cache": {
+            "hashes": [
+                "sha256:764f93d3fa860be72125a568c2cc8eafb151cf29b4dc2515433a56ee657e1c60",
+                "sha256:c8420cf096f3aafde13c374979c21844752e2694ffd8710e6764685bb577ac90"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.7' and python_version < '4.0'",
+            "version": "==1.1.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==1.16.0"
+        },
+        "url-normalize": {
+            "hashes": [
+                "sha256:d23d3a070ac52a67b83a1c59a0e68f8608d1cd538783b401bc9de2c0fac999b2",
+                "sha256:ec3c301f04e5bb676d333a7fa162fa977ad2ca04b7e652bfc9fac4e405728eed"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
+            "version": "==1.4.3"
+        },
         "urllib3": {
             "hashes": [
-                "sha256:55901e917a5896a349ff771be919f8bd99aff50b79fe58fec595eb37bbc56bb3",
-                "sha256:df7aa8afb0148fa78488e7899b2c59b5f4ffcfa82e6c54ccb9dd37c1d7b52d54"
+                "sha256:051d961ad0c62a94e50ecf1af379c3aba230c66c710493493560c0c223c49f20",
+                "sha256:ce3711610ddce217e6d113a2732fafad960a03fd0318c91faa79481e35c11224"
             ],
             "markers": "python_version >= '3.8'",
-            "version": "==2.1.0"
+            "version": "==2.2.0"
         }
     },
     "develop": {}

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Currently implemented:
 1. Clone this project: `git clone https://github.com/glensc/plex-fuse`
 1. Change to `plex-fuse` directory
 1. Install project dependencies `pipenv install`
-1. Create [config.ini](#plex-config) for `python-plex`
+1. Create [config.ini](#plex-config) for `python-plexapi`
 1. Mount the configured PMS somewhere, i.e `plex-server`: `mkdir plex-server; pipenv run python -m plexfuse plex-server -f`
 1. Access the `plex-server` directory from another terminal
 1. `umount` or `fusermount -u` the directory to remove the `plex-server` mount

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ Currently implemented:
 - [ ] Add timestamps to directories
 - [x] Add subtitle files for Movies
 - [x] Add subtitle files for Episodes
+- [x] Cache PlexAPI requests using requests-cache (`-o http_cache`)
 - [ ] Publish package to pypi
 - [ ] Add docker volume driver
 - [ ] Add cache management (max size?)

--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -20,6 +20,7 @@ class PlexFS(fuse.Fuse):
         plex = PlexApi()
         self.vfs = PlexVFS(plex)
         self.cache_path = None
+        self.http_cache = None
         self.file_map = RefCountedDict()
         self.iolock = Lock()
 
@@ -28,6 +29,7 @@ class PlexFS(fuse.Fuse):
         # https://github.com/libfuse/python-fuse/issues/61#issuecomment-1902472620
         cache_path = self.cache_path if self.cache_path else PlexApi.CACHE_PATH
         PlexApi.CACHE_PATH = Path(cache_path).absolute()
+        PlexApi.HTTP_CACHE = self.http_cache
 
     @cache
     def getattr(self, path: str):

--- a/plexfuse/fs/main.py
+++ b/plexfuse/fs/main.py
@@ -22,6 +22,9 @@ def main():
     server.parser.add_option(mountopt="cache_path", metavar="PATH",
                              default=PlexApi.CACHE_PATH,
                              help="cache downloads under PATH [default: %default]")
+    server.parser.add_option(mountopt="http_cache",
+                             default=False, action="store_true",
+                             help="cache http requests using requests-cache")
     server.parse(values=server, errex=1)
     server.main()
 

--- a/plexfuse/plex/HttpCache.py
+++ b/plexfuse/plex/HttpCache.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from datetime import timedelta
 from functools import cached_property
 from typing import TYPE_CHECKING
 
@@ -15,7 +16,18 @@ class HttpCache:
     def urls_expire_after(self):
         from requests_cache import DO_NOT_CACHE
 
+        CACHE_1h = 60 * 60
+        CACHE_1d = timedelta(days=1)
+
         return {
+            "*/library/sections/*/all?includeGuids=1": CACHE_1d,
+            "*/library/sections/*/all?includeGuids=1&type=3": CACHE_1h,
+            "*/library/sections/*/all?includeGuids=1&type=4": CACHE_1h,
+
+            # Some reload
+            "*/library/metadata/*": CACHE_1d,
+
+            # default policy is not to cache
             "*": DO_NOT_CACHE,
         }
 

--- a/plexfuse/plex/HttpCache.py
+++ b/plexfuse/plex/HttpCache.py
@@ -54,6 +54,9 @@ class HttpCache:
 
         return CachedSession(
             cache_name=str(self.cache_path),
-            cache_control=True,
+            # Plex sends "Cache-Control: no-cache" headers
+            cache_control=False,
             urls_expire_after=self.urls_expire_after,
+            # Plex doesn't Send Vary: X-Plex-Container-Start
+            match_headers=['X-Plex-Container-Start'],
         )

--- a/plexfuse/plex/HttpCache.py
+++ b/plexfuse/plex/HttpCache.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import timedelta
 from functools import cached_property
 from typing import TYPE_CHECKING
@@ -34,6 +35,22 @@ class HttpCache:
     @cached_property
     def session(self):
         from requests_cache import CachedSession
+
+        # Set log levels
+        loggers = [
+            "requests_cache.session",
+            "requests_cache.policy.actions",
+            "requests_cache.policy.expiration",
+            "requests_cache.backends",
+            "requests_cache.backends.base",
+            "requests_cache.backends.sqlite",
+        ]
+        stderr_handler = logging.StreamHandler()
+
+        for name in loggers:
+            logger = logging.getLogger(name)
+            logger.setLevel(logging.DEBUG)
+            logger.addHandler(stderr_handler)
 
         return CachedSession(
             cache_name=str(self.cache_path),

--- a/plexfuse/plex/HttpCache.py
+++ b/plexfuse/plex/HttpCache.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+from functools import cached_property
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+class HttpCache:
+    def __init__(self, cache_path: Path):
+        self.cache_path = cache_path
+
+    @property
+    def urls_expire_after(self):
+        from requests_cache import DO_NOT_CACHE
+
+        return {
+            "*": DO_NOT_CACHE,
+        }
+
+    @cached_property
+    def session(self):
+        from requests_cache import CachedSession
+
+        return CachedSession(
+            cache_name=str(self.cache_path),
+            cache_control=True,
+            urls_expire_after=self.urls_expire_after,
+        )

--- a/plexfuse/plex/PlexApi.py
+++ b/plexfuse/plex/PlexApi.py
@@ -20,12 +20,16 @@ class PlexApi:
     CACHE_PATH = Path("cache")
     CACHE_VERSION = str(2)
     CHUNK_SIZE = 1024 * 1024 * 16
+    HTTP_CACHE = False
 
     @cached_property
     def server(self):
-        http_cache = HttpCache(self.CACHE_PATH / "http_cache")
+        session = None
+        if self.HTTP_CACHE:
+            http_cache = HttpCache(self.CACHE_PATH / "http_cache")
+            session = http_cache.session
 
-        return PlexServer(session=http_cache.session)
+        return PlexServer(session=session)
 
     @property
     def session(self):

--- a/plexfuse/plex/PlexApi.py
+++ b/plexfuse/plex/PlexApi.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING
 
 from plexapi.server import PlexServer
 
+from plexfuse.plex.HttpCache import HttpCache
 from plexfuse.plexvfs.LibraryEntry import LibraryEntry
 from plexfuse.plexvfs.MovieEntry import MovieEntry
 from plexfuse.plexvfs.SectionEntry import SectionEntry
@@ -22,7 +23,9 @@ class PlexApi:
 
     @cached_property
     def server(self):
-        return PlexServer()
+        http_cache = HttpCache(self.CACHE_PATH / "http_cache")
+
+        return PlexServer(session=http_cache.session)
 
     @property
     def session(self):


### PR DESCRIPTION
Can be enabled by a mount option:

```
Usage: PlexFS: A filesystem for mounting a Plex Media Server media

app.py [mountpoint] [options]

Options:
    --version              show program's version number and exit
    -h, --help             show this help message and exit
    -o opt,[opt...]        mount options
    -o cache_path=PATH     cache downloads under PATH [default: cache]
    -o http_cache          cache http requests using requests-cache
FUSE options:
    -d   -o debug          enable debug output (implies -f)
    -f                     foreground operation
    -s                     disable multi-threaded operation

fuse: no mount point
```