### PR TITLE
Package all packages

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,4 +49,4 @@ version = {attr = "plexfuse.__version__.__version__"}
 plex-fuse = "plexfuse.fs.main:main"
 
 [tool.setuptools]
-packages = ["plexfuse"]
+packages = ["plexfuse", "plexfuse.fs", "plexfuse.plex", "plexfuse.plexvfs"]


### PR DESCRIPTION
This build system sucks, it takes files from previous build leaving me to believe all is well.

need to run build from pristine directory to see actual results. another release wasted. doh

not sure which of these matters. i thought "build" but nope.

```
rm -rf plexfuse/plex_fuse.egg-info dist build plex_fuse.egg-info plex_fuse-0.3.1-py3-none-any.whl
```