### PR TITLE
Add get_size method to find fresh part from playable

### DIFF
--- a/plexfuse/vfs/entry/FileEntry.py
+++ b/plexfuse/vfs/entry/FileEntry.py
@@ -13,7 +13,7 @@ if TYPE_CHECKING:
 
 class FileEntry(AttrEntry):
     def __init__(self, part: MediaPart, playable: Playable, reader: ChunkedFile):
-        self.size = part.size if part.exists else None
+        self.size = self.get_size(playable, part)
         self.key = part.key
         self.playable = playable
         self.reader = reader

--- a/plexfuse/vfs/entry/FileEntry.py
+++ b/plexfuse/vfs/entry/FileEntry.py
@@ -25,6 +25,14 @@ class FileEntry(AttrEntry):
         except AttributeError:
             return {}
 
+    @staticmethod
+    def get_size(playable: Playable, part: MediaPart):
+        if playable.item.isPartialObject():
+            playable.item.reload()
+        part = next(partx for partx in playable.item.iterParts() if partx.key == part.key)
+        size = part.size if part.exists else None
+        return size
+
     def read(self, offset: int, size: int):
         return self.reader.read(self.key, size=size, offset=offset, max_size=self.size)
 


### PR DESCRIPTION
Appears the original MediaPart is not a full object.

This is quick workaround, should figure a way to fix the original part object.