### PR TITLE
Feature: Add control socket

### DIFF
--- a/plexfuse/control/ControlListener.py
+++ b/plexfuse/control/ControlListener.py
@@ -1,12 +1,19 @@
+from __future__ import annotations
+
 import os
 import os.path
 import socket
 from threading import Thread
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from plexfuse.vfs.Control import Control
 
 
 class ControlListener:
-    def __init__(self, path: str):
+    def __init__(self, path: str, control: Control):
         self.path = path
+        self.control = control
         self.thread = None
         self.socket = None
 

--- a/plexfuse/control/ControlListener.py
+++ b/plexfuse/control/ControlListener.py
@@ -1,0 +1,62 @@
+import os
+import os.path
+import socket
+from threading import Thread
+
+
+class ControlListener:
+    def __init__(self, path: str):
+        self.path = path
+        self.thread = None
+        self.socket = None
+
+    def start(self):
+        self.socket = self.listen_socket()
+        self.thread = self.create_thread(self.handle)
+
+    def stop(self):
+        self.close_socket()
+        self.stop_thread()
+
+    @staticmethod
+    def create_thread(handler):
+        thread = Thread(target=handler, daemon=True)
+        thread.start()
+        return thread
+
+    def stop_thread(self):
+        if self.thread is None:
+            return
+
+        if self.thread.is_alive():
+            self.thread.join()
+
+        self.thread = None
+
+    def listen_socket(self):
+        if os.path.exists(self.path):
+            os.unlink(self.path)
+
+        server = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        server.bind(self.path)
+        server.listen()
+
+        return server
+
+    def close_socket(self):
+        self.socket.close()
+        if os.path.exists(self.path):
+            os.unlink(self.path)
+        self.socket = None
+
+    def handle(self):
+        while True:
+            conn, addr = self.socket.accept()
+            datagram = conn.recv(128)
+            if datagram:
+                tokens = datagram.decode().strip().split()
+                if tokens[0].lower() == "post":
+                    conn.send(f"{len(tokens)}".encode())
+                else:
+                    conn.send(b"Bye\n")
+            conn.close()

--- a/plexfuse/control/ControlListener.py
+++ b/plexfuse/control/ControlListener.py
@@ -62,8 +62,9 @@ class ControlListener:
             datagram = conn.recv(128)
             if datagram:
                 tokens = datagram.decode().strip().split()
-                if tokens[0].lower() == "post":
-                    conn.send(f"{len(tokens)}".encode())
+                if tokens[0] in self.control.commands:
+                    response = self.control.action(tokens[0])
+                    conn.send(response)
                 else:
                     conn.send(b"Bye\n")
             conn.close()

--- a/plexfuse/vfs/Control.py
+++ b/plexfuse/vfs/Control.py
@@ -60,6 +60,10 @@ class Control:
         yield from self.cc_sections.cache_info()
         yield from self.cc_library.cache_info()
 
+    def action(self, action: str):
+        method = getattr(self, action)
+        return "\n".join(method()).encode() + b"\n"
+
     def handle(self, pc: int, pe: list[str]):
         if pc == 1 and pe[0] in self.root:
             return DirEntry(self.commands)

--- a/tests/test_socket_control.py
+++ b/tests/test_socket_control.py
@@ -1,0 +1,22 @@
+from time import sleep
+
+from plexfuse.control.ControlListener import ControlListener
+
+
+def test_socket_control():
+    s = ControlListener("/tmp/ControlListener.sock")
+    s.start()
+
+    try:
+        for i in range(100):
+            print(f"Main thread idling: {i}...")
+            sleep(10)
+    except KeyboardInterrupt as e:
+        print(e)
+    finally:
+        s.stop()
+    print("Main thread exiting")
+
+
+if __name__ == "__main__":
+    test_socket_control()

--- a/tests/test_socket_control.py
+++ b/tests/test_socket_control.py
@@ -1,10 +1,18 @@
 from time import sleep
 
 from plexfuse.control.ControlListener import ControlListener
+from plexfuse.fs.PlexFS import PlexFS
+from plexfuse.plex.PlexApi import PlexApi
+from plexfuse.vfs.Control import Control
+from plexfuse.vfs.PlexVFS import PlexVFS
 
 
 def test_socket_control():
-    s = ControlListener("/tmp/ControlListener.sock")
+    p = PlexApi()
+    fs = PlexFS()
+    vfs = PlexVFS(p, fs)
+    c = Control(p, fs, vfs)
+    s = ControlListener("/tmp/ControlListener.sock", c)
     s.start()
 
     try:


### PR DESCRIPTION
Currently, the control socket via fuse is limited:
1. fuse layer caches results
2. can not predict response size without running command
3. can not use size 0 on macos, as then nothing can be read

Add unix socket support, outside fuse mount

Server:

```
$ FUSE_PYTHON_API=0.1 PYTHONPATH=. python tests/test_socket_control.py
```


Client:
```
$ echo status | socat - UNIX-CONNECT:/tmp/ControlListener.sock
$ echo reload | socat - UNIX-CONNECT:/tmp/ControlListener.sock
```