### PR TITLE
Feature: Add control.sock symlink if control sock is enabled.

### DIFF
--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -70,6 +70,22 @@ class PlexFS(fuse.Fuse):
         return PlexFile(st_size=item.size, **item.attr)
 
     @cache
+    def readlink(self, path: str):
+        path = normalize(path, is_path=True)
+        try:
+            item = self.vfs[path]
+        except KeyError as e:
+            print(f"ERROR: readlink: Unsupported path: {e}")
+            return -errno.ENOENT
+
+        link = item.link
+        if link is None:
+            print(f"ERROR: readlink: value for {path} is None")
+            return -errno.EINVAL
+
+        return link
+
+    @cache
     def readdir(self, path: str, offset: int):
         return list(self._readdir(path))
 

--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -13,7 +13,6 @@ from plexfuse.fs.RefCountedDict import RefCountedDict
 from plexfuse.normalize import normalize
 from plexfuse.plex.Monitor import Monitor
 from plexfuse.plex.PlexApi import PlexApi
-from plexfuse.vfs.Control import Control
 from plexfuse.vfs.entry.DirEntry import DirEntry
 from plexfuse.vfs.PlexVFS import PlexVFS
 
@@ -49,8 +48,7 @@ class PlexFS(fuse.Fuse):
         print(f"fsinit: control_path={self.options.control_path}")
         print(f"fsinit: listen_events={self.options.listen_events}")
         if self.options.control_path:
-            control = Control(self.plex, self, self.vfs)
-            self.control = ControlListener(self.options.control_path, control).start()
+            self.control = ControlListener(self.options.control_path, self.vfs.control).start()
         if self.options.listen_events:
             self.monitor = Monitor(self.plex).start()
 

--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -1,5 +1,5 @@
 import errno
-from functools import cache
+from functools import cache, cached_property
 from pathlib import Path
 from threading import Lock
 
@@ -25,12 +25,18 @@ class PlexFS(fuse.Fuse):
     def __init__(self, *args, **kw):
         super().__init__(*args, **kw)
         self.options = FsOptions()
-        self.plex = plex = PlexApi()
-        self.vfs = PlexVFS(plex, self)
         self.control = None
         self.monitor = None
         self.file_map = RefCountedDict()
         self.iolock = Lock()
+
+    @cached_property
+    def plex(self):
+        return PlexApi()
+
+    @cached_property
+    def vfs(self):
+        return PlexVFS(self.plex, self)
 
     def fsinit(self):
         # "cache_path" property doesn't get always initialized from options:

--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -35,7 +35,7 @@ class PlexFS(fuse.Fuse):
 
     @cached_property
     def vfs(self):
-        return PlexVFS(self.plex, self)
+        return PlexVFS(self.plex, self, self.options.control_path)
 
     def fsinit(self):
         # "cache_path" property doesn't get always initialized from options:

--- a/plexfuse/vfs/Control.py
+++ b/plexfuse/vfs/Control.py
@@ -21,10 +21,11 @@ if TYPE_CHECKING:
 class Control:
     CONTROL_DIR = "control"
 
-    def __init__(self, plex: PlexApi, plexfs: PlexFS, plexvfs: PlexVFS):
+    def __init__(self, plex: PlexApi, plexfs: PlexFS, plexvfs: PlexVFS, control_path: str = None):
         self.plex = plex
         self.plexfs = plexfs
         self.plexvfs = plexvfs
+        self.control_path = control_path
 
     @property
     def root(self):

--- a/plexfuse/vfs/Control.py
+++ b/plexfuse/vfs/Control.py
@@ -19,6 +19,8 @@ if TYPE_CHECKING:
 
 
 class Control:
+    CONTROL_DIR = "control"
+
     def __init__(self, plex: PlexApi, plexfs: PlexFS, plexvfs: PlexVFS):
         self.plex = plex
         self.plexfs = plexfs
@@ -26,7 +28,9 @@ class Control:
 
     @property
     def root(self):
-        return ["control"]
+        return [
+            self.CONTROL_DIR,
+        ]
 
     @property
     def commands(self):
@@ -65,10 +69,10 @@ class Control:
         return "\n".join(method()).encode() + b"\n"
 
     def handle(self, pc: int, pe: list[str]):
-        if pc == 1 and pe[0] in self.root:
+        if pc == 1 and pe[0] == self.CONTROL_DIR:
             return DirEntry(self.commands)
 
-        if pc != 2 or pe[0] != self.root[0]:
+        if pc != 2 or pe[0] != self.CONTROL_DIR:
             return
 
         if pe[1] in self.commands:

--- a/plexfuse/vfs/PlexVFS.py
+++ b/plexfuse/vfs/PlexVFS.py
@@ -7,8 +7,8 @@ from plexfuse.vfs.ChunkedFile import ChunkedFile
 from plexfuse.vfs.Control import Control
 from plexfuse.vfs.entry.DirEntry import DirEntry
 from plexfuse.vfs.entry.FileEntry import FileEntry
-from plexfuse.vfs.entry.SubtitleEntry import SubtitleEntry
 from plexfuse.vfs.entry.PlexMatchEntry import PlexMatchEntry
+from plexfuse.vfs.entry.SubtitleEntry import SubtitleEntry
 
 if TYPE_CHECKING:
     from plexfuse.fs.PlexFS import PlexFS
@@ -18,11 +18,11 @@ if TYPE_CHECKING:
 class PlexVFS(UserDict):
     SUBTITLE_EXT = (".srt", ".vtt")
 
-    def __init__(self, plex: PlexApi, plexfs: PlexFS):
+    def __init__(self, plex: PlexApi, plexfs: PlexFS, control_path: str = None):
         super().__init__()
         self.plex = plex
         self.reader = ChunkedFile(plex)
-        self.control = Control(plex, plexfs, self)
+        self.control = Control(plex, plexfs, self, control_path)
 
     def __missing__(self, path: str):
         entry = self.resolve(path)

--- a/plexfuse/vfs/entry/ControlSockEntry.py
+++ b/plexfuse/vfs/entry/ControlSockEntry.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+import stat
+
+from plexfuse.vfs.entry.AttrEntry import AttrEntry
+
+
+class ControlSockEntry(AttrEntry):
+    def __init__(self, name: str, control_path: str):
+        self.name = name
+        self.size = 0
+        self.link = control_path
+
+    @property
+    def attr(self):
+        return {
+            "st_mode": stat.S_IFLNK | 0o644
+        }


### PR DESCRIPTION
```
lrw-r--r-- 1 root wheel 0 Apr 10 12:35 control.sock -> /tmp/control.sock=
```

as can't create socket inside fuse filesystem, need to place them on real filesystem, but we can symlink to it for convenience.