### PR TITLE
Fix: Time out io lock after a timeout

### DIFF
--- a/plexfuse/TimeoutLock.py
+++ b/plexfuse/TimeoutLock.py
@@ -1,0 +1,20 @@
+from contextlib import AbstractContextManager
+from threading import Lock
+
+
+class TimeoutLock(AbstractContextManager):
+    def __init__(self, timeout: float = -1):
+        self.lock = Lock()
+        self.timeout = timeout
+        self.result = None
+
+    def __enter__(self):
+        self.result = self.lock.acquire(timeout=self.timeout)
+        if not self.result:
+            raise RuntimeError(f"Unable to acquire lock in {self.timeout} seconds")
+        return self
+
+    def __exit__(self, __exc_type, __exc_value, __traceback):
+        if self.result:
+            self.lock.release()
+        self.result = None

--- a/plexfuse/fs/PlexFS.py
+++ b/plexfuse/fs/PlexFS.py
@@ -1,7 +1,6 @@
 import errno
 from functools import cache, cached_property
 from pathlib import Path
-from threading import Lock
 
 import fuse
 
@@ -14,6 +13,7 @@ from plexfuse.fs.RefCountedDict import RefCountedDict
 from plexfuse.normalize import normalize
 from plexfuse.plex.Monitor import Monitor
 from plexfuse.plex.PlexApi import PlexApi
+from plexfuse.TimeoutLock import TimeoutLock
 from plexfuse.vfs.entry.DirEntry import DirEntry
 from plexfuse.vfs.PlexVFS import PlexVFS
 
@@ -28,7 +28,7 @@ class PlexFS(fuse.Fuse):
         self.control = None
         self.monitor = None
         self.file_map = RefCountedDict()
-        self.iolock = Lock()
+        self.iolock = TimeoutLock(60)
 
     @cached_property
     def plex(self):

--- a/tests/test_timeout_lock.py
+++ b/tests/test_timeout_lock.py
@@ -1,0 +1,26 @@
+from time import sleep
+
+from plexfuse.TimeoutLock import TimeoutLock
+
+
+def test_timeout_lock():
+    lock = TimeoutLock()
+    with lock:
+        assert True, "1s lock"
+
+    lock = TimeoutLock(1)
+    with lock:
+        assert True, "1s lock"
+
+    lock = TimeoutLock(0.5)
+    with lock:
+        assert True, "0.5s lock"
+
+        try:
+            with lock:
+                assert False, "Never reached"
+        except RuntimeError:
+            assert True, "Nested lock failure"
+
+        sleep(1)
+        assert True, "Tested nested lock"


### PR DESCRIPTION
> Ma vist mõtlesin välja mis probleem võiks olla. Et mul seal driveris kõik io operationid single iolock all. Ja kui mingi operation jääb rippuma siis kogu filesystem on ummikus. Peaks mingi timeout lisama mis jõuga viskam lukust välja.

Refs:
- https://docs.python.org/3/library/contextlib.html