### PR TITLE
Contrib: Add remount-fuse.c source code

### DIFF
--- a/contrib/remount-fuse.c
+++ b/contrib/remount-fuse.c
@@ -1,0 +1,62 @@
+//
+// https://stackoverflow.com/questions/28302178/how-can-i-add-a-volume-to-an-existing-docker-container/77944759#77944759
+//
+// $ gcc remount-fuse.c -o remount-fuse
+//
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+#include <sched.h>
+#include <fcntl.h>
+#include <unistd.h>
+
+#include <linux/mount.h>
+
+#include <errno.h>
+#include <sys/syscall.h>
+
+int main(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: ./a.out pid src_dir dst_dir\n");
+        return 0;
+    }
+
+    char *pid = argv[1];
+    char *src_dir = argv[2];
+    char *dst_dir = argv[3];
+
+    int fd_mnt;
+    fd_mnt = syscall(__NR_open_tree, 
+        -EBADF, src_dir, OPEN_TREE_CLONE);
+
+    if (fd_mnt < 0) {
+        perror("open_tree failed");
+        return 1;
+    }
+
+    char mount_namespace[1000];
+    snprintf(mount_namespace, 1000, "/proc/%s/ns/mnt", pid);
+    int fd_mntns = open(mount_namespace, O_RDONLY);
+
+    if (fd_mntns < 0) {
+        printf("open /proc/%s/ns/mnt failed: %s", pid, strerror(errno));
+        return 1;
+    }
+
+    setns(fd_mntns, 0);
+
+    int ret = syscall(__NR_move_mount, 
+        fd_mnt, "", -EBADF, dst_dir, MOVE_MOUNT_F_EMPTY_PATH );
+
+    if (ret < 0) {
+        perror("move_mount failed");
+        return 1;
+    }
+
+    printf("mounted %s to %s of namespace %s\n", src_dir, dst_dir, mount_namespace);
+    return 0;
+}

--- a/contrib/remount-fuse.c
+++ b/contrib/remount-fuse.c
@@ -13,7 +13,7 @@
 #include <fcntl.h>
 #include <unistd.h>
 
-#include <linux/mount.h>
+#include <sys/mount.h>
 
 #include <errno.h>
 #include <sys/syscall.h>
@@ -48,6 +48,12 @@ int main(int argc, char **argv)
     }
 
     setns(fd_mntns, 0);
+
+    // remove previous mount
+    int ret1 = umount2(dst_dir, MNT_DETACH);
+    if (ret1 < 0) {
+        perror("umount2 failed");
+    }
 
     int ret = syscall(__NR_move_mount, 
         fd_mnt, "", -EBADF, dst_dir, MOVE_MOUNT_F_EMPTY_PATH );

--- a/contrib/remount-fuse.c
+++ b/contrib/remount-fuse.c
@@ -20,8 +20,8 @@
 
 int main(int argc, char **argv)
 {
-    if (argc < 3) {
-        printf("usage: ./a.out pid src_dir dst_dir\n");
+    if (argc < 4) {
+        printf("usage: %s PID src_dir dst_dir\n", argv[0]);
         return 0;
     }
 


### PR DESCRIPTION
This can be used to remount docker container volume from host.

Let's assume plex container is bind mounted with:

```yml
volumes:
- /run/user/1000/plexfuse/Plex:/media/plexfuse/Plex
```

you remount `/run/user/1000/plexfuse/Plex` in the host, but plex container remains with detached fuse connection.

To solve this need to update mount in container.

Build and install the tool:

```sh
gcc contrib/remount-fuse.c -o remount-fuse
sudo install -s remount-fuse /usr/local/bin/remount-fuse
```

To remount the volume in running container:

```sh
pid=$(pidof 'Plex Media Server')
sudo remount-fuse "$pid" /run/user/1000/plexfuse/Plex /media/plexfuse/Plex
```

Source from:
- https://stackoverflow.com/questions/28302178/how-can-i-add-a-volume-to-an-existing-docker-container/77944759#77944759
