### PR TITLE
Do not error out with sentry_sdk package not installed

### DIFF
--- a/plexfuse/sentry/sentry.py
+++ b/plexfuse/sentry/sentry.py
@@ -5,7 +5,11 @@ def sentry(dsn: str = None):
     if not dsn:
         return
 
-    import sentry_sdk
+    try:
+        import sentry_sdk
+    except ImportError:
+        print("Unable to init sentry: sentry_sdk package not installed")
+        return
 
     sentry_sdk.init(
         dsn=dsn,


### PR DESCRIPTION
You can use `pipx inject` to install extra packages:

```
$ pipx inject plex-fuse sentry-sdk==2.1.1
```